### PR TITLE
fix issue #101: Allow to collapse comments & guidance

### DIFF
--- a/config/initializers/_dmproadmap_ugent.rb
+++ b/config/initializers/_dmproadmap_ugent.rb
@@ -123,7 +123,7 @@ module DMPRoadmap
     config.x.application.require_contributor_email = true
 
     # Defines if Guidances/Comments in toggleable & if it's opened by default
-    config.x.application.guidance_comments_toggleable = false
+    config.x.application.guidance_comments_toggleable = true
     # do not set this to false when guidance_comments_toggleable is also
     # false. Reason: comments won't be displayed and there is no way
     # to show them again by toggling


### PR DESCRIPTION
Fixes #101  .

Not collapsed:

![Screenshot 2024-10-31 at 11 45 35](https://github.com/user-attachments/assets/1f1d6d4c-dab9-4a4e-938d-09e99ec21ce4)


Collapsed:

![Screenshot 2024-10-31 at 11 45 43](https://github.com/user-attachments/assets/9ef0dbf7-038d-40b2-9648-6c27558a0a02)

I do not have an opinion about a contrasting color. Everything is black and white here. The example from the issue is stemming from a different style (dcc?).