### PR TITLE
disable and untested external apis

### DIFF
--- a/config/initializers/external_apis/z_disable_local.rb
+++ b/config/initializers/external_apis/z_disable_local.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# local override
+
+# disable new external apis (see config/initializers/external_apis/*.rb)
+Rails.configuration.x.doi.active = false
+Rails.configuration.x.open_aire.active = false
+Rails.configuration.x.rdamsc.active = false
+Rails.configuration.x.re3data.active = false
+Rails.configuration.x.ror.active = false
+Rails.configuration.x.spdx.active = false

--- a/ugent/CHANGES.txt
+++ b/ugent/CHANGES.txt
@@ -588,6 +588,12 @@
 
   Please set DMP_HOST and DMP_PROTOCOL in your environment
 
+- config/initializers/external_apis/z_disable_local.rb
+
+  overrides settings as set by previous config/initializers/external_apis/*.rb
+
+  it is important to keep this name alphabetically last
+
 - config/initializers/devise_ugent.rb
 
   overrides settings from config/initializers/devise.rb


### PR DESCRIPTION
Fixes #104

The user cannot save his input to field "Grant number" because
it is an autocomplete field that wants to find a value in some openaire
api (but that does not work apparently). Anyway, as with other autocomplete
fields in dmproadmap (e.g. "Funder"), the input is cleared on save when the autocomplete does
not return anything.

The autocomplete feature is enabled by setting `Rails.configuration.x.open_aire.active` (boolean),
and is used in `app/views/plans/_project_details.html.erb` (and therefore also in the branded view
`app/views/branded/plans/_project_details.html.erb`. I see no difference between those views when
it comes that setting:

```
$ diff app/views/plans/_project_details.html.erb app/views/branded/plans/_project_details.html.erb 
2a3
> <!-- BELNET: All we do here is changing the value of id_tooltip -->
6c7
< id_tooltip = _('A pertinent ID as determined by the funder and/or organisation.')
---
> id_tooltip = _('Modifiable automatically assigned number.')
```

So either this field never worked, or the default setting of `Rails.configuration.x.open_aire.active` has been set to `true` recently.

Nevertheless, this should it. It also took the liberty to set the other settings to false. Apparently none of those are used anywhere in the code, but we should not forget about those.