### PR TITLE
fix for #105: enable all checkboxes by default on export tab

### DIFF
--- a/config/initializers/_dmproadmap_ugent.rb
+++ b/config/initializers/_dmproadmap_ugent.rb
@@ -197,6 +197,9 @@ module DMPRoadmap
     # regardless of the plans visibility and whether or not the plan has been shared
     config.x.plans.super_admins_read_all = true
 
+    # Check download of a plan coversheet tickbox
+    config.x.plans.download_coversheet_tickbox_checked = true
+
     # --------------------------------------------------- #
     # Machine Actionable / Networked DMP Features (maDMP) #
     # --------------------------------------------------- #


### PR DESCRIPTION
Fixes part of  #105 :  enable all checkboxes in the plan export tab