### PR TITLE
fix regression as introduced by commit

### DIFF
--- a/app/views/branded/shared/export/_plan_coversheet.erb
+++ b/app/views/branded/shared/export/_plan_coversheet.erb
@@ -5,20 +5,13 @@
 <div class="cover-page">
   <p><b><%= _("Title: ") %></b><%= @hash[:title] %></p><br>
 
-  <p><strong><%= _("Creator:") %></strong><%= @hash[:attribution] %></p><br>
-
-  <%# Added contributors to coverage of plans. 
-    # Users will see both roles and contributor names if the role is filled %>
-  <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
-  <% if @hash[:investigation].present? %>
-  <p><b><%= _("Principal Investigator: ") %></b><%= @hash[:investigation].map(&:name).join(', ') %></p><br>
-  <% end %>
-  <% if @hash[:data_curation].present? %>
-  <p><b><%= _("Data Manager: ") %></b><%= @hash[:data_curation].map(&:name).join(', ') %></p><br>
-  <% end %>
-  <% if @hash[:pa].present? %>
-  <p><b><%= _("Project Administrator: ") %></b><%= @hash[:pa].map(&:name).join(', ') %></p><br>
-  <% end %>
+  <p>
+    <% owner_and_coowners = @plan.owner_and_coowners %>
+    <b><%= owner_and_coowners.size > 1 ? _("Creators: ") : _("Creator: ") %></b>
+    <%= owner_and_coowners.map { |u| u.name_with_orcid }
+                          .join(", ")
+                          .html_safe %>
+  </p><br>
 
   <p><b><%= _("Affiliation: ") %></b><%= @hash[:affiliation] %></p><br>
 
@@ -47,6 +40,16 @@
                        .html_safe %>
     </p><br>
 
+  <% end %>
+
+  <% admins = @plan.contributors.project_administration.all %>
+  <% if admins.size > 0 %>
+    <p>
+      <b>Project Administrator:</b>
+      <%= admins.map { |c| c.to_user.name_with_orcid }
+               .join(", ")
+               .html_safe %>
+    </p><br>
   <% end %>
 
   <% if @plan.description.present? %>


### PR DESCRIPTION
Fixes part of #105 

Problems since commit 6b544564deda389429ac235d0c1d22122408bd4c
* plan coversheet now shows principal investigators and data managers twice, once above with only the name (https://github.com/DMPbelgium/roadmap/blob/master/app/views/branded/shared/export/_plan_coversheet.erb#L13) like it is in the upstream DCC version, and secondly at the bottom with ORCID appended (if any) (https://github.com/DMPbelgium/roadmap/blob/master/app/views/branded/shared/export/_plan_coversheet.erb#L31) (which we introduced)
* plan coversheet no longer shows both owner and coowners in tag "Creator" with their ORCID appended (if any)
* plan coversheet no longer shows project administrators

Changes proposed in this PR:
- removed first tags for "principal investigator" and "data manager" (where only the name is mentioned), and keep the others (at the bottom)
- replace tag "creator" by "creator" or "creators", listing both owners and coowners with their orcid appended (like it was before)
- added orcid back to project administrators

Unsure about
- previously the plan title was added to the header of the coversheet, while now it shows "Plan overview". The plan title is still visible though in the first tag "title" though. @laurastandaert does it matter?


6b544564deda389429ac235d0c1d22122408bd4c